### PR TITLE
fix(docker-start): Redirect access/error logs to std-out (#470)

### DIFF
--- a/{{cookiecutter.github_repository}}/compose/dev/django/start
+++ b/{{cookiecutter.github_repository}}/compose/dev/django/start
@@ -7,4 +7,4 @@ set -o nounset
 
 python /app/manage.py collectstatic --noinput
 # /usr/local/bin/gunicorn asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn.workers.UvicornWorker
-/usr/local/bin/gunicorn wsgi --bind 0.0.0.0:5000 --chdir=/app
+/usr/local/bin/gunicorn wsgi --bind 0.0.0.0:5000 --chdir=/app --access-logfile - --error-logfile -


### PR DESCRIPTION
> Why was this change necessary?

When deployed on services like ECS, the logs aren't captured since they are not on the standard output and standard error streams.

> How does it address the problem?

Redirect output/error to std-out/std-err streams.

> Are there any side effects?

None.

> Why was this change necessary?

add your text here...

> How does it address the problem?

add your text here...

> Are there any side effects?

add your text here...
